### PR TITLE
Implement post-queue track handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 *.cache-overthinkingme
-SpotToPhones.log
-HPhonesAPI.py
-
-dev/APITest.py
-dev/config.ini
-dev/return.txt
+*.log
+dev/*

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -10,7 +10,7 @@ import logging
 import ConfigParser
 
 Config = ConfigParser.ConfigParser()
-Config.read("dev/config.ini")
+Config.read("config.ini")
 logging.basicConfig(filename='SpotToPhones.log',level=logging.DEBUG)
 pp = pprint.PrettyPrinter(indent=4, depth=2)
 playlist_data = []

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -73,7 +73,7 @@ def getSpotTracks(sp):
                 'Error Playlist Name': ConfigSectionMap("GENERAL")['error_playlist'],
                 'Error Playlist ID': playlist['id']
                 }
-        if playlist['name'] == ConfigSectionMap("GENERAL")['wanted_playlist']:
+        if playlist['name'] == ConfigSectionMap("GENERAL")['snatched_playlist']:
             pdata2 = {
                 'Snatched Playlist Name': ConfigSectionMap("GENERAL")['snatched_playlist'],
                 'Snatched Playlist ID': playlist['id']
@@ -318,6 +318,10 @@ def main():
     #pp.pprint(hp_track_data)
     print(playlist_data[0]['Wanted Playlist Name'])
     print(playlist_data[0]['Wanted Playlist ID'])
+    print(playlist_data[0]['Error Playlist Name'])
+    print(playlist_data[0]['Error Playlist ID'])
+    print(playlist_data[0]['Snatched Playlist Name'])
+    print(playlist_data[0]['Snatched Playlist ID'])
     print("")
 
     for x in range(0,len(track_data)):
@@ -329,5 +333,5 @@ def main():
         print("Track Test: ", track_data[x]['Track Test'])
         print("Track URI: ", track_data[x]['URI'])
         print("")
-    '''    
+    '''
 main()

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -259,14 +259,36 @@ def remFromSpotPlaylist(sp, tracks):
     '''
     username = ConfigSectionMap("SPOTIPY")['user']
     playlist_id = playlist_data[0]['Playlist ID']
-    remCommand = sp.user_playlist_remove_all_occurrences_of_tracks(username,playlist_id,tracks)
+    remCall = sp.user_playlist_remove_all_occurrences_of_tracks(username,playlist_id,tracks)
 
+def toSpotPlaylist(sp, playlist, tracks):
+    #   results = sp.user_playlist_add_tracks(username, playlist_id, track_ids)
+    #   doc: user_playlist_add_tracks(user, playlist_id, tracks, position=None)
+    #   tracks is a LIST of track id's
+    username = ConfigSectionMap("SPOTIPY")['user']
+    playlists = sp.user_playlists(username)
+    for pl in playlists['items']:
+        if pl['name'] == playlist_name:
+            pl_id = pl['id']
+    addCall = sp.user_playlist_add_tracks(username, pl_id, tracks)
+    
 def toErrorPL():
+    ''' Albums which were not matched successfully and/or not queued
+        will be moved to a new playlist
+    '''
     error_playlist = ConfigSectionMap("GENERAL")['error_playlist']
-
+    username = ConfigSectionMap("SPOTIPY")['user']
+    playlists = sp.user_playlists(username)
+    
+    
 def toSnatchedPL():
+    ''' Albums which were matched successfully and/or queued
+        will be moved to a new playlist
+    '''
     snatched_playlist = ConfigSectionMap("GENERAL")['snatched_playlist']
-
+    username = ConfigSectionMap("SPOTIPY")['user']
+    playlists = sp.user_playlists(username)
+    
 def main():
     sp = callSpotify()
     track_data = getSpotTracks(sp)

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -63,28 +63,28 @@ def getSpotTracks(sp):
     playlist_found_test = 0
     for playlist in playlists['items']:
         #Get playlist id's of all our playlists in one go
-        if playlist['name'] == playlist_name:
-            pdata = {
-                'Wanted Playlist Name': playlist_name,
-                'Wanted Playlist ID': playlist['id']
-                }
         if playlist['name'] == ConfigSectionMap("GENERAL")['error_playlist']:
             pdata1 = {
                 'Error Playlist Name': ConfigSectionMap("GENERAL")['error_playlist'],
                 'Error Playlist ID': playlist['id']
                 }
+            playlist_data.append(pdata1)
         if playlist['name'] == ConfigSectionMap("GENERAL")['snatched_playlist']:
             pdata2 = {
                 'Snatched Playlist Name': ConfigSectionMap("GENERAL")['snatched_playlist'],
                 'Snatched Playlist ID': playlist['id']
                 }
-            playlist_data.append(pdata)
-            playlist_data.append(pdata1)
             playlist_data.append(pdata2)
+        if playlist['name'] == playlist_name:
+            pdata = {
+                'Wanted Playlist Name': playlist_name,
+                'Wanted Playlist ID': playlist['id']
+                }
+            playlist_data.append(pdata)
             tracks = sp.user_playlist(username, playlist['id'], fields="tracks")
             playlist_found_test = 1
             break
-
+        
     if playlist_found_test == 0:
         logging.debug("Did not find playlist.")
         sys.exit()

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -17,7 +17,7 @@ playlist_data = []
 
 
 def ConfigSectionMap(section):
-    ''' Return vars from config.ini to a dict object
+    ''' Return vars from config.ini to a dict object.
     '''
     dict1 = {}
     options = Config.options(section)
@@ -36,7 +36,7 @@ def ConfigSectionMap(section):
 hp_api = "http://" + ConfigSectionMap("HEADPHONES")['ip'] + ":" + ConfigSectionMap("HEADPHONES")['port'] +  ConfigSectionMap("HEADPHONES")['webroot'] + "/api"
 
 def callSpotify():
-    ''' Get and return Auth Token from Spotify for API calls
+    ''' Get and return Auth Token from Spotify for API calls.
     '''
     app_scope = ConfigSectionMap("SPOTIPY")['scope']
     username = ConfigSectionMap("SPOTIPY")['user']
@@ -53,8 +53,8 @@ def callSpotify():
         sys.exit()
 
 def getSpotTracks(sp):
-    ''' Get playlist tracks' artist and album information
-        Returns a dict object with all tracks' information
+    ''' Get playlist tracks' artist and album information.
+        Returns a dict object with all tracks' information.
     '''
     username = ConfigSectionMap("SPOTIPY")['user']
     playlists = sp.user_playlists(username)
@@ -113,8 +113,8 @@ def callHeadphones(req):
     return result
 
 def modHeadphones(req):
-    ''' Handles POST calls to Headphones API
-        Returns response 'OK' if successful
+    ''' Handles POST calls to Headphones API.
+        Returns response 'OK' if successful.
     '''
     global hp_api
     data = {'apikey': ConfigSectionMap("HEADPHONES")['api_key']}
@@ -132,9 +132,9 @@ def modHeadphones(req):
     return result.text
 
 def checkHeadphones(track_data):
-    ''' Calls Headphones API to check if tracks are present in library
-        Appends artist and/or album id's to track_data dict
-        If information is not found, will store string 'notfound'
+    ''' Calls Headphones API to check if tracks are present in library.
+        Appends artist and/or album id's to track_data dict.
+        If information is not found, will store string 'notfound'.
     '''
     req = {'cmd': 'getIndex'}
     hp_index = callHeadphones(req)
@@ -186,9 +186,9 @@ def checkHeadphones(track_data):
     return track_data
 
 def getMusicbrainzArtistID(sp_artist_name):
-    ''' Queries Headphone's API Musicbrainz query method to get Musicbrainz artist id
-        Returns Musicbrainz artist id
-        if unable to acquire, returns string 'notfound'
+    ''' Queries Headphone's API Musicbrainz query method to get Musicbrainz artist id.
+        Returns Musicbrainz artist id.
+        if unable to acquire, returns string 'notfound'.
     '''
     hp_artist_id = ''
     req = {'cmd': 'findArtist', 'name': sp_artist_name, 'limit': 10}
@@ -213,9 +213,9 @@ def getMusicbrainzArtistID(sp_artist_name):
     return hp_artist_id
 
 def getMusicbrainzAlbumID(hp_artist_id, sp_album_name):
-    ''' Queries Headphone's API Musicbrainz query method to get Musicbrainz album id
-        Returns Musicbrainz album id
-        if unable to acquire, returns string 'notfound'
+    ''' Queries Headphone's API Musicbrainz query method to get Musicbrainz album id.
+        Returns Musicbrainz album id.
+        if unable to acquire, returns string 'notfound'.
     '''
     hp_album_id = ''
     req = {'cmd': 'findAlbum', 'name': sp_album_name, 'limit': 15}
@@ -238,8 +238,8 @@ def getMusicbrainzAlbumID(hp_artist_id, sp_album_name):
     return hp_album_id
 
 def queueAlbum(sp, hp_track_data):
-    ''' Request tracks' album is downloaded by calling Headphones API
-        If artist id and/or album id is string 'notfound', does nothing 
+    ''' Request tracks' album is downloaded by calling Headphones API.
+        If artist id and/or album id is string 'notfound', does nothing. 
     '''
     snatchedTracks = []
     errorTracks = []
@@ -278,7 +278,7 @@ def queueAlbum(sp, hp_track_data):
     addToErrorPL(sp, errorTracks)
     
 def remFromSpotPlaylist(sp, tracks):
-    ''' Calls on Spotify API to remove track from wanted_playlist if download requested
+    ''' Calls on Spotify API to remove tracks from wanted_playlist if download requested
         Method does not give option to choose what playlist to remove from, possibly in future if needed.
     '''
     username = ConfigSectionMap("SPOTIPY")['user']
@@ -286,15 +286,15 @@ def remFromSpotPlaylist(sp, tracks):
     remCall = sp.user_playlist_remove_all_occurrences_of_tracks(username,playlist_id,tracks)
 
 def addToSpotPlaylist(sp, playlist_id, tracks):
-    #   results = sp.user_playlist_add_tracks(username, playlist_id, track_ids)
-    #   doc: user_playlist_add_tracks(user, playlist_id, tracks, position=None)
-    #   tracks is a LIST of track id's
+    ''' Calls on Spotify API to add tracks to a playlist.
+        Playlist is specified by arg:playlist_id when called.
+    '''
     username = ConfigSectionMap("SPOTIPY")['user']
     addCall = sp.user_playlist_add_tracks(username, playlist_id, tracks)
     
 def addToErrorPL(sp, tracks):
     ''' Albums which were not matched successfully and/or not queued
-        will be moved to a new playlist
+        will be moved to a new playlist.
     '''
     playlist_id = playlist_data[0]['Error Playlist ID']
     addToSpotPlaylist(sp, playlist_id, tracks)
@@ -302,7 +302,7 @@ def addToErrorPL(sp, tracks):
     
 def addToSnatchedPL(sp, tracks):
     ''' Albums which were matched successfully and/or queued
-        will be moved to a new playlist
+        will be moved to a new playlist.
     '''
     playlist_id = playlist_data[0]['Snatched Playlist ID']
     addToSpotPlaylist(sp, playlist_id, tracks)

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -62,38 +62,36 @@ def getSpotTracks(sp):
 
     wanted_playlist_found_test = 0
     playlist_found_count = 0
+    pdata = {}
     for playlist in playlists['items']:
         #Get playlist id's of all our playlists in one go
         if playlist['name'] == ConfigSectionMap("GENERAL")['error_playlist']:
-            pdata1 = {
-                'Error Playlist Name': ConfigSectionMap("GENERAL")['error_playlist'],
-                'Error Playlist ID': playlist['id']
-                }
-            playlist_data.append(pdata1)
+            pdata['Error Playlist Name'] = ConfigSectionMap("GENERAL")['error_playlist']
+            pdata['Error Playlist ID'] = playlist['id']
             playlist_found_count += 1
         if playlist['name'] == ConfigSectionMap("GENERAL")['snatched_playlist']:
-            pdata2 = {
-                'Snatched Playlist Name': ConfigSectionMap("GENERAL")['snatched_playlist'],
-                'Snatched Playlist ID': playlist['id']
-                }
-            playlist_data.append(pdata2)
+            pdata['Snatched Playlist Name'] = ConfigSectionMap("GENERAL")['snatched_playlist']
+            pdata['Snatched Playlist ID'] = playlist['id']
             playlist_found_count += 1
         if playlist['name'] == playlist_name:
-            pdata = {
-                'Wanted Playlist Name': playlist_name,
-                'Wanted Playlist ID': playlist['id']
-                }
-            playlist_data.append(pdata)
+            pdata['Wanted Playlist Name'] = playlist_name
+            pdata['Wanted Playlist ID'] = playlist['id']
             playlist_found_count += 1
-            tracks = sp.user_playlist(username, playlist['id'], fields="tracks")
             wanted_playlist_found_test = 1
         if playlist_found_count >= 3: #dup playlist names allowed?
             break
         
+    playlist_data.append(pdata)
+    tracks = sp.user_playlist(username, pdata['Wanted Playlist ID'], fields="tracks")
+        
     if wanted_playlist_found_test == 0:
-        logging.debug("Did not find playlist.")
+        logging.debug("Did not find wanted playlist.")
         sys.exit()
-
+        
+    if playlist_found_count < 3:
+        logging.debug("Did not find one of snatched or error playlists.")
+        sys.exit()
+        
     track_data = []
 
     for track in tracks['tracks']['items']:
@@ -280,6 +278,7 @@ def queueAlbum(sp, hp_track_data):
                         
     remFromSpotPlaylist(sp, snatchedTracks) #does not specify playlist id
     addToSnatchedPL(sp, snatchedTracks)
+    remFromSpotPlaylist(sp, errorTracks)
     addToErrorPL(sp, errorTracks)
     
 def remFromSpotPlaylist(sp, tracks):

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -60,7 +60,7 @@ def getSpotTracks(sp):
     playlists = sp.user_playlists(username)
     playlist_name = ConfigSectionMap("GENERAL")['wanted_playlist']
 
-    playlist_found_test = 0
+    wanted_playlist_found_test = 0
     playlist_found_count = 0
     for playlist in playlists['items']:
         #Get playlist id's of all our playlists in one go
@@ -86,11 +86,11 @@ def getSpotTracks(sp):
             playlist_data.append(pdata)
             playlist_found_count += 1
             tracks = sp.user_playlist(username, playlist['id'], fields="tracks")
-            playlist_found_test = 1
+            wanted_playlist_found_test = 1
         if playlist_found_count >= 3: #dup playlist names allowed?
             break
         
-    if playlist_found_test == 0:
+    if wanted_playlist_found_test == 0:
         logging.debug("Did not find playlist.")
         sys.exit()
 

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -312,8 +312,6 @@ def main():
     track_data = getSpotTracks(sp)
     track_data = checkHeadphones(track_data)
     queueAlbum(sp, track_data)
-    toSnatchedPL(sp, track_data)
-    toErrorPL(sp, track_data)
 
     '''
     ### TESTING ###

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -61,6 +61,7 @@ def getSpotTracks(sp):
     playlist_name = ConfigSectionMap("GENERAL")['wanted_playlist']
 
     playlist_found_test = 0
+    playlist_found_count = 0
     for playlist in playlists['items']:
         #Get playlist id's of all our playlists in one go
         if playlist['name'] == ConfigSectionMap("GENERAL")['error_playlist']:
@@ -69,20 +70,24 @@ def getSpotTracks(sp):
                 'Error Playlist ID': playlist['id']
                 }
             playlist_data.append(pdata1)
+            playlist_found_count += 1
         if playlist['name'] == ConfigSectionMap("GENERAL")['snatched_playlist']:
             pdata2 = {
                 'Snatched Playlist Name': ConfigSectionMap("GENERAL")['snatched_playlist'],
                 'Snatched Playlist ID': playlist['id']
                 }
             playlist_data.append(pdata2)
+            playlist_found_count += 1
         if playlist['name'] == playlist_name:
             pdata = {
                 'Wanted Playlist Name': playlist_name,
                 'Wanted Playlist ID': playlist['id']
                 }
             playlist_data.append(pdata)
+            playlist_found_count += 1
             tracks = sp.user_playlist(username, playlist['id'], fields="tracks")
             playlist_found_test = 1
+        if playlist_found_count >= 3: #dup playlist names allowed?
             break
         
     if playlist_found_test == 0:
@@ -334,4 +339,5 @@ def main():
         print("Track URI: ", track_data[x]['URI'])
         print("")
     '''
+    
 main()

--- a/SpotToPhones.py
+++ b/SpotToPhones.py
@@ -10,7 +10,7 @@ import logging
 import ConfigParser
 
 Config = ConfigParser.ConfigParser()
-Config.read("config.ini")
+Config.read("dev/config.ini")
 logging.basicConfig(filename='SpotToPhones.log',level=logging.DEBUG)
 pp = pprint.PrettyPrinter(indent=4, depth=2)
 playlist_data = []
@@ -260,6 +260,12 @@ def remFromSpotPlaylist(sp, tracks):
     username = ConfigSectionMap("SPOTIPY")['user']
     playlist_id = playlist_data[0]['Playlist ID']
     remCommand = sp.user_playlist_remove_all_occurrences_of_tracks(username,playlist_id,tracks)
+
+def toErrorPL():
+    error_playlist = ConfigSectionMap("GENERAL")['error_playlist']
+
+def toSnatchedPL():
+    snatched_playlist = ConfigSectionMap("GENERAL")['snatched_playlist']
 
 def main():
     sp = callSpotify()

--- a/config.ini
+++ b/config.ini
@@ -5,7 +5,7 @@
 [GENERAL]
 wanted_playlist: {playlist name}
 error_playlist: {playlist name}
-completed_playlist: {playlist name}
+snatched_playlist: {playlist name}
 
 [SPOTIPY]
 scope: playlist-read-private playlist-modify-private


### PR DESCRIPTION
Post-queueAlbum, tracks will be moved to either snatched_playlist or error_playlist in Spotify.
Playlists are defined in the config file.
Tested handling working correctly.
